### PR TITLE
Add SELLPRICE, BUYPRICE, STASH, MERC, %LBRACE%/%RBRACE%, and ~ range operator

### DIFF
--- a/data/custom_items.js
+++ b/data/custom_items.js
@@ -1972,8 +1972,7 @@ function setPD2Codes() {
 	}
 	if (settings.version == 1) {
 		document.getElementById("character_class").style.display = "inline-table"
-		document.getElementById("character_shop").style.display = "inline-table"
-		document.getElementById("character_equipped").style.display = "inline-table"
+		document.getElementById("character_location").style.display = "inline"
 		document.getElementById("character_gold").style.display = "none"
 		if (selected_group_index < 9) { document.getElementById("select_price").style.display = "block" }	// shows price for all equipment groups (excludes "charm", "socketable", "miscellaneous")
 		if (selected_group_index > 9) {
@@ -1997,8 +1996,7 @@ function setPD2Codes() {
 		// TODO: Reset list of pointmods when changing between versions (can currently be done manually by changing the basic item info)
 	} else {
 		document.getElementById("character_class").style.display = "none"
-		document.getElementById("character_shop").style.display = "none"
-		document.getElementById("character_equipped").style.display = "none"
+		document.getElementById("character_location").style.display = "none"
 		document.getElementById("character_gold").style.display = "inline-table"
 		if (selected_group_index < 9) { document.getElementById("select_price").style.display = "block" }	// shows price for all equipment groups (excludes "charm", "socketable", "miscellaneous")
 		if (selected_group_index > 9) {

--- a/data/custom_items.js
+++ b/data/custom_items.js
@@ -2041,6 +2041,8 @@ function setPrice(val) {
 	if (val > max) { val = max }
 	document.getElementById("price").value = val
 	itemToCompare.PRICE = val
+	itemToCompare.BUYPRICE = val
+	itemToCompare.SELLPRICE = val
 	simulate()
 }
 

--- a/data/item_metadata.js
+++ b/data/item_metadata.js
@@ -1598,7 +1598,7 @@ var all_codes = {
 	AXE:3,MACE:3,SWORD:3,DAGGER:3,THROWING:3,JAV:2,SPEAR:3,POLEARM:3,BOW:3,XBOW:3,STAFF:3,WAND:3,SCEPTER:3,_1H:2,_2H:2,	// JAV is a valid code in PoD, but doesn't seem to match with javelins
 	wss:2,lbox:2,dcma:2,dcbl:2,dcho:2,dcso:2,imra:2,imma:2,scou:2,rera:2,upma:2,upmp:2,scrb:2,ubtm:2,jewf:2,rtma:2,rtmo:2,rtmv:2,rtmf:2,cwss:2,rar:2,rbe:2,ram:2,rid:2,rtp:2,lpp:2,llmr:2,lsvl:2,ubaa:2,ubab:2,ubac:2,uba:2,rkey:2,fort:2,lmal:2,iwss:2,cm2f:2,pvpp:2,irma:2,irra:2,urma:2,rrra:2,
 	AMAZON:2,ASSASSIN:2,BARBARIAN:2,DRUID:2,NECROMANCER:2,PALADIN:2,SORCERESS:2,
-	PREFIX:2,SUFFIX:2,MAPID:2,SHOP:2,EQUIPPED:2,GEMMED:2,GROUND:2,INVENTORY:2,QUIVER:2,imrn:2,luca:2,lucb:2,lucc:2,lucd:2,_7cr2:2,cm1p:2,cm2p:2,cm3p:2,BUYPRICE:2,
+	PREFIX:2,SUFFIX:2,MAPID:2,SHOP:2,EQUIPPED:2,GEMMED:2,GROUND:2,INVENTORY:2,STASH:2,MERC:2,QUIVER:2,imrn:2,luca:2,lucb:2,lucc:2,lucd:2,_7cr2:2,cm1p:2,cm2p:2,cm3p:2,BUYPRICE:2,SELLPRICE:2,
 	t10:2,t11:2,t12:2,t13:2,t14:2,t15:2,t16:2,t17:2,t18:2,t20:2,t19:2,t21:2,t22:2,t23:2,t24:2,t25:2,t26:2,t27:2,t28:2,t29:2,t30:2,t31:2,t32:2,t33:2,t34:2,t35:2,t36:2,t37:2,t38:2,t39:2,t3a:2,t40:2,t41:2,t42:2,t43:2,t44:2,t45:2,t46:2,t47:2,t48:2,t49:2,t50:2,t51:2,t52:2,t53:2,t54:2,t55:2,t56:2,t57:2,t58:2,t59:2,t60:2,t61:2,t62:2,t63:2,t64:2,t65:2,t66:2,t67:2,t68:2,t69:2,
 	r01s:2,r02s:2,r03s:2,r04s:2,r05s:2,r06s:2,r07s:2,r08s:2,r09s:2,r10s:2,r11s:2,r12s:2,r13s:2,r14s:2,r15s:2,r16s:2,r17s:2,r18s:2,r19s:2,r20s:2,r21s:2,r22s:2,r23s:2,r24s:2,r25s:2,r26s:2,r27s:2,r28s:2,r29s:2,r30s:2,r31s:2,r32s:2,r33s:2,
 	tpfs:2,tpfm:2,tpfl:2,tpgs:2,tpgm:2,tpgl:2,tpcs:2,tpcm:2,tpcl:2,tpls:2,tplm:2,tpll:2,

--- a/data/simulation.js
+++ b/data/simulation.js
@@ -1480,36 +1480,14 @@ function setGoldChar(value) {
 	character.CHARSTAT14 = Number(value)
 	simulate()
 }
-// setShop - handles 'shop' checkbox
+// setLocation - handles location radio group (None/Shop/Equipped/Stash/Merc/Ground)
 // ---------------------------------
-function setShop(checked) {
-	character.SHOP = checked
-	if (checked == true) { if (character.EQUIPPED == true) {
-		document.getElementById("equipped").checked = false;
-		character.EQUIPPED = false;
-	} }
-	simulate()
-}
-// setEquipped - handles 'equipped' checkbox
-// ---------------------------------
-function setEquipped(checked) {
-	character.EQUIPPED = checked
-	if (checked == true) { if (character.SHOP == true) {
-		document.getElementById("shop").checked = false;
-		character.SHOP = false;
-	} }
-	simulate()
-}
-// setStash - handles 'stash' checkbox
-// ---------------------------------
-function setStash(checked) {
-	character.STASH = checked
-	simulate()
-}
-// setMerc - handles 'merc' checkbox
-// ---------------------------------
-function setMerc(checked) {
-	character.MERC = checked
+function setLocation(value) {
+	character.SHOP     = (value == "SHOP")
+	character.EQUIPPED = (value == "EQUIPPED")
+	character.STASH    = (value == "STASH")
+	character.MERC     = (value == "MERC")
+	character.GROUND   = (value == "GROUND")
 	simulate()
 }
 // setFilterLevel -

--- a/data/simulation.js
+++ b/data/simulation.js
@@ -1,6 +1,6 @@
 
 var itemToCompare = {name:"5000 Gold",NAME:"5000 Gold",CODE:"GOLD",GOLD:5000,ID:true,always_id:true,rarity:"regular"};
-var character = {CLVL:90,CHARSTAT14:199000,CHARSTAT15:199000,DIFFICULTY:2,ILVL:85,CHARSTAT70:0,CHARSTAT13:1000,AMAZON:true,ASSASSIN:false,BARBARIAN:false,DRUID:false,NECROMANCER:false,PALADIN:false,SORCERESS:false,SHOP:false,EQUIPPED:false,GROUND:false,INVENTORY:false,FILTLVL:1};
+var character = {CLVL:90,CHARSTAT14:199000,CHARSTAT15:199000,DIFFICULTY:2,ILVL:85,CHARSTAT70:0,CHARSTAT13:1000,AMAZON:true,ASSASSIN:false,BARBARIAN:false,DRUID:false,NECROMANCER:false,PALADIN:false,SORCERESS:false,SHOP:false,EQUIPPED:false,GROUND:false,INVENTORY:false,STASH:false,MERC:false,FILTLVL:1};
 var item_settings = {ID:false, ILVL_return:85};
 var settings = {auto_difficulty:true,version:0,validation:1,auto_simulate:1,max_errors:50,error_limit:1,num_filters:2,background:0,nowrap:true,nowrap_width:745};
 var notices = {duplicates:0,pd2_conditions:0,pod_conditions:0,colors:0,encoding:0};
@@ -245,6 +245,8 @@ function setItem(value) {
 			itemToCompare.NAME = value.split(" (")[0].split(" ­ ")[0]
 			itemToCompare.ILVL = 85
 			itemToCompare.PRICE = Number(document.getElementById("price").value)
+			itemToCompare.BUYPRICE = itemToCompare.PRICE
+			itemToCompare.SELLPRICE = itemToCompare.PRICE
 			itemToCompare.ID = true;
 			if (typeof(itemToCompare.base) != 'undefined') {
 				var base = bases[itemToCompare.base.split(" ").join("_").split("-").join("_").split("s'").join("s").split("'s").join("s")];
@@ -585,6 +587,9 @@ function parseFile(file,num) {
 			}
 			if (index_end > index+12 && rule.substring(0,index).length == 0) {
 				conditions = conditions.split(",").join("‚")	// Refactors "MULTI" conditions since they use commas (uses the "Single low-9 quotation mark" instead of "comma")
+				// Expand range operator ~: !CODE~min-max → (CODE<min OR CODE>max), CODE~min-max → CODE>=min CODE<=max
+				conditions = conditions.replace(/!(\w+)~(-?\d+)-(-?\d+)/g, '($1<$2 OR $1>$3)');
+				conditions = conditions.replace(/(\w+)~(-?\d+)-(-?\d+)/g, '$1>=$2 $1<=$3');
 				var match_override = false;
 				var cond_format = conditions.split("  ").join(" ").split("(").join(",(,").split(")").join(",),").split("!").join(",!,").split("<=").join(",≤,").split(">=").join(",≥,").split(">").join(",>,").split("<").join(",<,").split("=").join(",=,").split(" AND ").join(" ").split(" OR ").join(",|,").split("+").join(",+,").split(" ").join(",&,").split(",,").join(",");
 				var cond_list = cond_format.split(",");
@@ -598,8 +603,7 @@ function parseFile(file,num) {
 				for (cond in cond_list) {
 					cond = Number(cond)
 					var c = cond_list[cond];
-					// TODO: Check whether the "BETEEN" operator is present and reconfigure it to use multiple conditions with ">" and "<" (may need a different solution for PREFIX/SUFFIX/AUTOMOD)
-					var nonbool_conditions = ["GOLD","RUNE","GEMLEVEL","GEMTYPE","QTY","DEF","LVLREQ","PRICE","BUYPRICE","ALVL","CRAFTALVL","QLVL","ILVL","SOCK","ED","MAXDUR","AR","RES","FRES","CRES","LRES","PRES","FRW","IAS","FCR","FHR","FBR","MINDMG","MAXDMG","STR","DEX","LIFE","MANA","MFIND","GFIND","MAEK","DTM","REPLIFE","REPAIR","ARPER","FOOLS","ALLSK"];
+					var nonbool_conditions = ["GOLD","RUNE","GEMLEVEL","GEMTYPE","QTY","DEF","LVLREQ","PRICE","BUYPRICE","SELLPRICE","ALVL","CRAFTALVL","QLVL","ILVL","SOCK","ED","MAXDUR","AR","RES","FRES","CRES","LRES","PRES","FRW","IAS","FCR","FHR","FBR","MINDMG","MAXDMG","STR","DEX","LIFE","MANA","MFIND","GFIND","MAEK","DTM","REPLIFE","REPAIR","ARPER","FOOLS","ALLSK"];
 					if (c == "GEM") { c = "GEMLEVEL" }
 					if (c == "RUNENUM" || c == "RUNENAME") { c = "RUNE" }
 					var number = false;
@@ -669,7 +673,7 @@ function parseFile(file,num) {
 						else if (~~Number(itemToCompare[c]) < 0) { value_is_negative = true }
 						// add to formula
 						if (c_falsify == true) { formula += "false " }
-						else if (c == "CLVL" || c == "DIFFICULTY" || c.substr(0,8) == "CHARSTAT" || c == "AMAZON" || c == "ASSASSIN" || c == "BARBARIAN" || c == "DRUID" || c == "NECROMANCER" || c == "PALADIN" || c == "SORCERESS" || c == "SHOP" || c == "EQUIPPED" || c == "GROUND" || c == "INVENTORY" || c == "FILTLVL") {
+						else if (c == "CLVL" || c == "DIFFICULTY" || c.substr(0,8) == "CHARSTAT" || c == "AMAZON" || c == "ASSASSIN" || c == "BARBARIAN" || c == "DRUID" || c == "NECROMANCER" || c == "PALADIN" || c == "SORCERESS" || c == "SHOP" || c == "EQUIPPED" || c == "GROUND" || c == "INVENTORY" || c == "STASH" || c == "MERC" || c == "FILTLVL") {
 							if (value_is_negative == true) { formula += (2000000000+Number(character[c]))+" " }			// converts negative values to their equivalent 'unsigned' value
 							else { formula += character[c]+" " }
 						}
@@ -740,7 +744,7 @@ function parseFile(file,num) {
 				out_format = out_format.split("%DGREEN%").join(",invalid_DGREEN,").split("%CLVL%").join(",invalid_CLVL,")
 				out_format = out_format.split("%DARK_GREEN%").join(",color_DGREEN,").split("%QTY%").join(",ref_QUANTITY,").split("%RANGE%").join(",ref_range,").split("%WPNSPD%").join(",ref_baseSpeed,").split("%ALVL%").join(",ref_ALVL,").split("%NL%").join(",misc_NL,").split("%MAP%").join(",ignore_MAP,").split("%NOTIFY-DEAD%").join(",ignore_NOTIFY-DEAD,").split("%LVLREQ%").join(",ref_reqlevel,").split("%CRAFTALVL%").join(",ref_CRAFTALVL,")
 				out_format = out_format.split("%LIGHT_GRAY%").join(",color_LIGHT_GRAY,").split("%CORAL%").join(",color_CORAL,").split("%SAGE%").join(",color_SAGE,").split("%TEAL%").join(",color_TEAL,")
-				out_format = out_format.split("%CLASS%").join(",invalid_CLASS,").split("%CL%").join(",misc_NL,").split("%QUAL%").join(",invalid_QUAL,").split("%QT%").join(",invalid_QT,").split("%BASENAME%").join(",ref_BASENAME,")
+				out_format = out_format.split("%CLASS%").join(",invalid_CLASS,").split("%CL%").join(",misc_NL,").split("%QUAL%").join(",invalid_QUAL,").split("%QT%").join(",invalid_QT,").split("%BASENAME%").join(",ref_BASENAME,").split("%LBRACE%").join(",misc_LBRACE,").split("%RBRACE%").join(",misc_RBRACE,")
 				if (settings.version == 1) {
 					var notifs = ["%PX-","%DOT-","%MAP-","%BORDER-"];
 					for (n in notifs) {									// TODO: implement more efficient way to split notification keywords
@@ -933,6 +937,7 @@ function parseFile(file,num) {
 	if (output_total.includes("{") == true && output_total.includes("}") == true) { if (output_total.indexOf("{") < output_total.lastIndexOf("}")) { description_active = true } }
 
 	var out_format = output_total.split(",").join("‾").split(" ").join(", ,").split("%CONTINUE%").join(",misc_CONTINUE,").split("%NAME%").join(",ref_NAME,").split("%BASENAME%").join(",ref_BASENAME,").split("%WHITE%").join(",color_WHITE,").split("%GRAY%").join(",color_GRAY,").split("%BLUE%").join(",color_BLUE,").split("%YELLOW%").join(",color_YELLOW,").split("%GOLD%").join(",color_GOLD,").split("%GREEN%").join(",color_GREEN,").split("%BLACK%").join(",color_BLACK,").split("%TAN%").join(",color_TAN,").split("%PURPLE%").join(",color_PURPLE,").split("%ORANGE%").join(",color_ORANGE,").split("%RED%").join(",color_RED,").split("%ILVL%").join(",ref_ILVL,").split("%SOCKETS%").join(",ref_SOCK,").split("%PRICE%").join(",ref_PRICE,").split("%RUNENUM%").join(",ref_RUNE,").split("%RUNENAME%").join(",ref_RUNENAME,").split("%GEMLEVEL%").join(",ref_GLEVEL,").split("%GEMTYPE%").join(",ref_GTYPE,").split("%CODE%").join(",ref_CODE,").split("\t").join(",\t,").split("{").join(",{,").split("}").join(",},").split("‗").join(",‗,");
+	out_format = out_format.split("%LBRACE%").join(",misc_LBRACE,").split("%RBRACE%").join(",misc_RBRACE,")
 	if (settings.version == 1) { out_format = out_format.split("%DARK_GREEN%").join(",color_DGREEN,").split("%QTY%").join(",ref_QUANTITY,").split("%RANGE%").join(",ref_range,").split("%WPNSPD%").join(",ref_baseSpeed,").split("%ALVL%").join(",ref_ALVL,").split("%NL%").join(",misc_NL,").split("%CL%").join(",misc_NL,").split("%MAP%").join(",ignore_MAP,").split("%NOTIFY-DEAD%").join(",ignore_NOTIFY-DEAD,").split("%LVLREQ%").join(",ref_reqlevel,").split("%CRAFTALVL%").join(",ref_CRAFTALVL,") }
 	if (settings.version == 1) { out_format = out_format.split("%LIGHT_GRAY%").join(",color_LIGHT_GRAY,").split("%CORAL%").join(",color_CORAL,").split("%SAGE%").join(",color_SAGE,").split("%TEAL%").join(",color_TEAL,") }
 	if (settings.version == 1) {
@@ -999,7 +1004,9 @@ function parseFile(file,num) {
 		var key = o.split("_")[0];
 		var blank = false;
 
-		if (key == "misc" || key == "ignore") {
+		if (o == "misc_LBRACE") { temp = "{" }
+		else if (o == "misc_RBRACE") { temp = "}" }
+		else if (key == "misc" || key == "ignore") {
 			blank = true
 		} else if (key == "color") {
 			blank = true
@@ -1491,6 +1498,18 @@ function setEquipped(checked) {
 		document.getElementById("shop").checked = false;
 		character.SHOP = false;
 	} }
+	simulate()
+}
+// setStash - handles 'stash' checkbox
+// ---------------------------------
+function setStash(checked) {
+	character.STASH = checked
+	simulate()
+}
+// setMerc - handles 'merc' checkbox
+// ---------------------------------
+function setMerc(checked) {
+	character.MERC = checked
 	simulate()
 }
 // setFilterLevel -

--- a/index.html
+++ b/index.html
@@ -56,10 +56,14 @@
 					<div style="display:inline"><label class="label">Difficulty: </label><select id="dropdown_difficulty" class="new-dropdown" onChange="setDifficulty(this.selectedIndex)">
 						<option class="gray-all">Normal</option><option class="gray-all">Nightmare</option><option class="gray-all">Hell</option><option class="gray-all" selected>Auto (ilvl-based)</option>
 					</select></div>
-					<div id="character_shop" style="display:inline"><label class="label" for="shop">&nbsp;Shop </label><input id="shop" type="checkbox" name="shop" onchange="setShop(this.checked)"></div>
-					<div id="character_equipped" style="display:inline"><label class="label" for="equipped">&nbsp;Equipped </label><input id="equipped" type="checkbox" name="equipped" onchange="setEquipped(this.checked)"></div>
-				<div id="character_stash" style="display:inline"><label class="label" for="stash">&nbsp;Stash </label><input id="stash" type="checkbox" name="stash" onchange="setStash(this.checked)"></div>
-				<div id="character_merc" style="display:inline"><label class="label" for="merc">&nbsp;Merc </label><input id="merc" type="checkbox" name="merc" onchange="setMerc(this.checked)"></div>
+					<div id="character_location" style="display:inline"><label class="label">&nbsp;State:</label>
+						<input type="radio" id="loc_none" name="location" value="NONE" checked onchange="setLocation(this.value)" style="display:none"><label for="loc_none" style="display:none">None</label>
+						<input type="radio" id="loc_shop" name="location" value="SHOP" onchange="setLocation(this.value)"><label class="label" for="loc_shop">Shop</label>
+						<input type="radio" id="loc_equipped" name="location" value="EQUIPPED" onchange="setLocation(this.value)"><label class="label" for="loc_equipped">Equipped</label>
+						<input type="radio" id="loc_stash" name="location" value="STASH" onchange="setLocation(this.value)"><label class="label" for="loc_stash">Stash</label>
+						<input type="radio" id="loc_merc" name="location" value="MERC" onchange="setLocation(this.value)"><label class="label" for="loc_merc">Merc</label>
+						<input type="radio" id="loc_ground" name="location" value="GROUND" onchange="setLocation(this.value)"><label class="label" for="loc_ground">Ground</label>
+					</div>
 				</div>
 				<div id="character_gold" style="display:inline-table;">
 					<div><label class="label" for="gold_stash">Gold in Stash: </label><input id="gold_stash" name="gold_stash" class="num-input" style="max-width:72px;" type="number" min="0" max="2500000" value="199000" onchange="setGoldStash(this.value)"></div>

--- a/index.html
+++ b/index.html
@@ -58,6 +58,8 @@
 					</select></div>
 					<div id="character_shop" style="display:inline"><label class="label" for="shop">&nbsp;Shop </label><input id="shop" type="checkbox" name="shop" onchange="setShop(this.checked)"></div>
 					<div id="character_equipped" style="display:inline"><label class="label" for="equipped">&nbsp;Equipped </label><input id="equipped" type="checkbox" name="equipped" onchange="setEquipped(this.checked)"></div>
+				<div id="character_stash" style="display:inline"><label class="label" for="stash">&nbsp;Stash </label><input id="stash" type="checkbox" name="stash" onchange="setStash(this.checked)"></div>
+				<div id="character_merc" style="display:inline"><label class="label" for="merc">&nbsp;Merc </label><input id="merc" type="checkbox" name="merc" onchange="setMerc(this.checked)"></div>
 				</div>
 				<div id="character_gold" style="display:inline-table;">
 					<div><label class="label" for="gold_stash">Gold in Stash: </label><input id="gold_stash" name="gold_stash" class="num-input" style="max-width:72px;" type="number" min="0" max="2500000" value="199000" onchange="setGoldStash(this.value)"></div>


### PR DESCRIPTION
## Summary
- `SELLPRICE` and `BUYPRICE` added as recognized numeric conditions, both wired to the existing Price input
- `%LBRACE%` and `%RBRACE%` output keywords render literal `{` and `}` without triggering description section logic
- `~` range operator now supported: `CODE~min-max` expands to `CODE>=min CODE<=max`; `!CODE~min-max` expands to `(CODE<min OR CODE>max)`
- Location conditions (`SHOP`, `EQUIPPED`, `STASH`, `MERC`, `GROUND`) consolidated into a single radio button group in the UI — only one can be active at a time, defaults to none, with a "Location:" header

## UI State
The Shop and Equipped checkboxes have been replaced by a **Location radio group**: None (hidden default) · Shop · Equipped · Stash · Merc · Ground. The old `setShop`/`setEquipped`/`setStash`/`setMerc` functions are replaced by a single `setLocation(value)` handler. The group is shown/hidden via `character_location` div (previously `character_shop` + `character_equipped`).

## Test plan
- [ ] `SELLPRICE<10` and `BUYPRICE>100` no longer throw unrecognized condition errors
- [ ] `%LBRACE%` and `%RBRACE%` render as `{` and `}` in item name output
- [ ] `FILTLVL~1-5` matches correctly; `RUNE~10-20` matches rune range; `!ILVL~80-99` excludes the range
- [ ] Location radio group appears in PD2 mode; selecting Shop/Equipped/Stash/Merc/Ground sets only that flag; deselecting resets to none
- [ ] No null reference errors on load (fixed `character_shop`/`character_equipped` ID references)

🤖 Generated with [Claude Code](https://claude.com/claude-code)