### PR TITLE
Fix MULTI condition to evaluate multi-layered stats

### DIFF
--- a/data/simulation.js
+++ b/data/simulation.js
@@ -663,7 +663,23 @@ function parseFile(file,num) {
 							if (typeof(character[c]) == 'undefined') { character[c] = 0 }
 							else if (~~Number(character[c]) < 0) { value_is_negative = true }
 						}
-						else if (typeof(itemToCompare[c]) == 'undefined' && (c.substr(0,4) == "STAT" || c.substr(0,5) == "MULTI" || c.substr(0,5) == "TABSK" || c.substr(0,4) == "CLSK" || c.substr(0,2) == "SK" || c.substr(0,4) == "CHSK" || c.substr(0,2) == "OS")) { itemToCompare[c] = 0 }
+						else if (typeof(itemToCompare[c]) == 'undefined' && c.substr(0,5) == "MULTI" && c.includes("‚")) {
+							var mParts = c.slice(5).split("‚");
+							var mStat = Number(mParts[0]);
+							var mLayer = Number(mParts[1]);
+							var mappedKey = null;
+							if (mStat == 107) { mappedKey = "SK" + mLayer; }
+							else if (mStat == 97) { mappedKey = "TABSK" + mLayer; }
+							else if (mStat == 83) { mappedKey = "CLSK" + mLayer; }
+							else if (mStat == 188) { mappedKey = "CHSK" + mLayer; }
+							else if (mStat == 126) { mappedKey = "OS" + mLayer; }
+							if (mappedKey != null && typeof(itemToCompare[mappedKey]) != 'undefined') {
+								itemToCompare[c] = itemToCompare[mappedKey];
+							} else {
+								itemToCompare[c] = 0;
+							}
+						}
+						else if (typeof(itemToCompare[c]) == 'undefined' && (c.substr(0,4) == "STAT" || c.substr(0,5) == "TABSK" || c.substr(0,4) == "CLSK" || c.substr(0,2) == "SK" || c.substr(0,4) == "CHSK" || c.substr(0,2) == "OS")) { itemToCompare[c] = 0 }
 						else if (typeof(itemToCompare[c]) == 'undefined') {
 							for (let i = 0; i < nonbool_conditions.length; i++) {
 								if (c == nonbool_conditions[i]) { itemToCompare[c] = 0 }


### PR DESCRIPTION
## Summary
- MULTI conditions (e.g. `MULTI107,262`) were parsed and recognized but always evaluated to 0, making them non-functional
- Now resolves MULTI stat ID + layer pairs to the corresponding item properties by mapping: stat 107→SK, 97→TABSK, 83→CLSK, 188→CHSK, 126→OS
- Example: `MULTI107,262+MULTI188,48+MULTI83,6=6` now correctly sums SK262 + CHSK48 + CLSK6 and compares to 6

Closes #12

## Test plan
- [ ] Load a filter with MULTI conditions (e.g. `ItemDisplay[SHOP SIN !SK262=0 MULTI107,262+MULTI188,48+MULTI83,6=6]`)
- [ ] Verify items with matching skill values are correctly matched by the rule
- [ ] Verify items without matching values are not matched
- [ ] Verify non-MULTI conditions (STAT, SK, TABSK, etc.) still work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)