### PR TITLE
Hotfix: harden ref_REROLLALVL against undefined inputs

### DIFF
--- a/data/simulation.js
+++ b/data/simulation.js
@@ -1575,7 +1575,7 @@ function parseFile(file,num) {
 			if (settings.validation == 1) { if (description_braces == 1) { text_length[2] += 3 } }
 		} else if (key == "ref") {
 			if (o == "ref_CLVL") { temp = character.CLVL }
-			else if (o == "ref_REROLLALVL") { temp = Math.round(Number(character.CLVL)/2) + Math.round(Number(itemToCompare.ILVL)/2) }
+			else if (o == "ref_REROLLALVL") { temp = Math.round(~~character.CLVL/2) + Math.round(~~itemToCompare.ILVL/2) }
 			else if (o == "ref_NAME") { blank = true }
 		else if (o == "ref_BASENAME") { temp = (typeof(itemToCompare.base) != 'undefined') ? itemToCompare.base : itemToCompare.NAME }
 			else if (settings.version == 1 && o == "ref_RUNENAME" && itemToCompare.RUNE > 0) { color = colors["ORANGE"]; temp = itemToCompare.name.split(" ")[0]; }	// TODO: why isn't itemToCompare.RUNENAME setup by this point? (for stacked runes)


### PR DESCRIPTION
## What

Replace `Number(...)` with `~~` in the `ref_REROLLALVL` resolver so undefined inputs coerce to `0` instead of `NaN`.

```diff
- else if (o == "ref_REROLLALVL") { temp = Math.round(Number(character.CLVL)/2) + Math.round(Number(itemToCompare.ILVL)/2) }
+ else if (o == "ref_REROLLALVL") { temp = Math.round(~~character.CLVL/2) + Math.round(~~itemToCompare.ILVL/2) }
```

## Why (best-theory, not confirmed)

User reports the merged PR #19 is causing crashes. Without the specific browser console error, the most plausible failure point in the diff is the new on-the-fly arithmetic — the only newly-added computation that runs at filter render time. `Number(undefined) === NaN` and propagating NaN through downstream length/string ops can produce visibly broken output that looks like a "crash" to a user.

`~~undefined === 0` and matches the surrounding style (e.g. `temp = ~~itemToCompare["req_level"]` two branches below).

## Caveats

- This is a defensive hotfix based on the most likely cause from reading the diff — not a confirmed reproduction. If symptoms persist after merging, please share the browser console error so a targeted fix can land.
- A more invasive alternative is to revert PR #19 in full (`gh pr revert 19`); say the word and I'll open that instead.
- The bumped superior `modmax` (15→20) and the new `all_codes` entries are untouched — those are additive and don't run computational code.

## Math semantics preserved

`Math.round(~~CLVL/2) + Math.round(~~ILVL/2)` = `round(CLVL/2) + round(ILVL/2)` for valid integers, exactly per the issue spec. Only the undefined-input behavior changes.