### PR TITLE
Fix #23 + #24: Add CHARM, JEWELRY, QUIVER, MISC bool conditions

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ The simulator recognizes a wide range of filter conditions including:
 - **Item properties**: NORM, EXC, ELT, NMAG, MAG, RARE, UNI, SET, ID, ETH, INF, SUP, RW, SOCK/SOCKETS, DEF, EDEF, EDAM, ED, MAXDUR, ILVL, QLVL, ALVL, CRAFTALVL, CRAFT, LVLREQ, QTY, PRICE, BUYPRICE, SELLPRICE
 - **Character stats**: CLVL, DIFF/DIFFICULTY, FILTLVL/FILTERLVL, CHARSTAT, GOLD, CLASS (PD2)
 - **Resistances and stats**: RES, FRES, CRES, LRES, PRES, AR, ARPER, FRW, IAS, FCR, FHR, FBR, MINDMG, MAXDMG, STR, DEX, LIFE, MANA, MFIND, GFIND, MAEK, DTM, REPLIFE, REPAIR, FOOLS, ALLSK
-- **Equipment types**: ARMOR, WEAPON, HELM, CHEST, SHIELD, GLOVES, BOOTS, BELT, CIRC, and all weapon categories (AXE, MACE, SWORD, DAGGER, SPEAR, POLEARM, BOW, XBOW, STAFF, WAND, SCEPTER, etc.)
+- **Equipment types**: ARMOR, WEAPON, CHARM, HELM, CHEST, SHIELD, GLOVES, BOOTS, BELT, CIRC, and all weapon categories (AXE, MACE, SWORD, DAGGER, SPEAR, POLEARM, BOW, XBOW, STAFF, WAND, SCEPTER, etc.)
 - **Class-specific codes**: DRU, BAR, DIN, NEC, SIN, SOR, ZON, plus class item codes (CL1-CL7, EQ1-EQ7, WP1-WP13)
 - **Skill codes**: SK, CLSK, TABSK ranges for all classes
 - **PD2-specific codes**: CHSK (skill charges), OS (oskills), MULTI (multi-layered stat conditions), PREFIX, SUFFIX, MAPID, MAPTIER, AMAZON/ASSASSIN/BARBARIAN/DRUID/NECROMANCER/PALADIN/SORCERESS, AUTOMOD, GEMMED, QUIVER, and various PD2 item codes

--- a/README.md
+++ b/README.md
@@ -54,10 +54,10 @@ The simulator recognizes a wide range of filter conditions including:
 - **Item properties**: NORM, EXC, ELT, NMAG, MAG, RARE, UNI, SET, ID, ETH, INF, SUP, RW, SOCK/SOCKETS, DEF, EDEF, EDAM, ED, MAXDUR, ILVL, QLVL, ALVL, CRAFTALVL, CRAFT, LVLREQ, QTY, PRICE, BUYPRICE, SELLPRICE
 - **Character stats**: CLVL, DIFF/DIFFICULTY, FILTLVL/FILTERLVL, CHARSTAT, GOLD, CLASS (PD2)
 - **Resistances and stats**: RES, FRES, CRES, LRES, PRES, AR, ARPER, FRW, IAS, FCR, FHR, FBR, MINDMG, MAXDMG, STR, DEX, LIFE, MANA, MFIND, GFIND, MAEK, DTM, REPLIFE, REPAIR, FOOLS, ALLSK
-- **Equipment types**: ARMOR, WEAPON, CHARM, HELM, CHEST, SHIELD, GLOVES, BOOTS, BELT, CIRC, and all weapon categories (AXE, MACE, SWORD, DAGGER, SPEAR, POLEARM, BOW, XBOW, STAFF, WAND, SCEPTER, etc.)
+- **Equipment types**: ARMOR, WEAPON, CHARM, JEWELRY, QUIVER, MISC, HELM, CHEST, SHIELD, GLOVES, BOOTS, BELT, CIRC, and all weapon categories (AXE, MACE, SWORD, DAGGER, SPEAR, POLEARM, BOW, XBOW, STAFF, WAND, SCEPTER, etc.)
 - **Class-specific codes**: DRU, BAR, DIN, NEC, SIN, SOR, ZON, plus class item codes (CL1-CL7, EQ1-EQ7, WP1-WP13)
 - **Skill codes**: SK, CLSK, TABSK ranges for all classes
-- **PD2-specific codes**: CHSK (skill charges), OS (oskills), MULTI (multi-layered stat conditions), PREFIX, SUFFIX, MAPID, MAPTIER, AMAZON/ASSASSIN/BARBARIAN/DRUID/NECROMANCER/PALADIN/SORCERESS, AUTOMOD, GEMMED, QUIVER, and various PD2 item codes
+- **PD2-specific codes**: CHSK (skill charges), OS (oskills), MULTI (multi-layered stat conditions), PREFIX, SUFFIX, MAPID, MAPTIER, AMAZON/ASSASSIN/BARBARIAN/DRUID/NECROMANCER/PALADIN/SORCERESS, AUTOMOD, GEMMED, and various PD2 item codes
 - **Location conditions**: SHOP, EQUIPPED, GROUND, INVENTORY, STASH, MERC
 - **All individual item codes** for bases, gems, runes (including PD2-specific stacked runes and uber items)
 

--- a/data/custom_items.js
+++ b/data/custom_items.js
@@ -490,6 +490,7 @@ function setCustomBase() {
 				if (base == "Small Charm") { itemCustom.CODE = "cm1" }
 				else if (base == "Large Charm") { itemCustom.CODE = "cm2" }
 				else if (base == "Grand Charm") { itemCustom.CODE = "cm3" }
+				itemCustom.CHARM = true
 			}
 			else if (type == "jewel") { itemCustom.CODE = "jew" }
 			else if (type == "quiver") {

--- a/data/custom_items.js
+++ b/data/custom_items.js
@@ -446,6 +446,7 @@ function setCustomBase() {
 	itemCustom.ILVL = document.getElementById("ilvl").value;
 
 	if (type == "rune" || type == "gem" || type == "other" || type == "misc") {
+		itemCustom.MISC = true
 		document.getElementById("select_rarity").style.display = "none"
 		for (itemNew in premade[type]) {
 			if (premade[type][itemNew].name == name) {
@@ -484,8 +485,8 @@ function setCustomBase() {
 			itemCustom.original_tier = itemCustom.tier;
 			if (itemCustom.tier == 1) { itemCustom.upgrade2 = bases[itemCustom.upgrade.split(" ").join("_").split("-").join("_").split("s'").join("s").split("'s").join("s")].upgrade }
 		} else {
-			if (type == "amulet") { itemCustom.CODE = "amu" }
-			else if (type == "ring") { itemCustom.CODE = "rin" }
+			if (type == "amulet") { itemCustom.CODE = "amu"; itemCustom.JEWELRY = true }
+			else if (type == "ring") { itemCustom.CODE = "rin"; itemCustom.JEWELRY = true }
 			else if (type == "charm") {
 				if (base == "Small Charm") { itemCustom.CODE = "cm1" }
 				else if (base == "Large Charm") { itemCustom.CODE = "cm2" }
@@ -495,6 +496,7 @@ function setCustomBase() {
 			else if (type == "jewel") { itemCustom.CODE = "jew" }
 			else if (type == "quiver") {
 				itemCustom.quiv = true
+				itemCustom.QUIVER = true
 				if (settings.version == 0) {
 					if (base == "Arrows") {
 						if (rarity == "Regular") { itemCustom.CODE = "aqv"; itemCustom.name = "Rusted Arrows"; itemCustom.NAME = "Rusted Arrows"; }

--- a/data/item_metadata.js
+++ b/data/item_metadata.js
@@ -1563,7 +1563,7 @@ var all_codes = {
 	NORM:3,EXC:3,ELT:3,NMAG:3,MAG:3,RARE:3,UNI:3,SET:3,ID:3,ETH:3,INF:3,SUP:3,RW:3,
 	CL1:3,CL2:3,CL3:3,CL4:3,CL5:3,CL6:3,CL7:3,
 	EQ1:3,EQ2:3,EQ3:3,EQ4:3,EQ5:3,EQ6:3,EQ7:3,ARMOR:3,
-	WP1:3,WP2:3,WP3:3,WP4:3,WP5:3,WP6:3,WP7:3,WP8:3,WP9:3,WP10:3,WP11:3,WP12:3,WP13:3,WEAPON:3,
+	WP1:3,WP2:3,WP3:3,WP4:3,WP5:3,WP6:3,WP7:3,WP8:3,WP9:3,WP10:3,WP11:3,WP12:3,WP13:3,WEAPON:3,CHARM:3,
 	amu:3,rin:3,aqv:3,cqv:3,aq2:1,cq2:1,aqv2:2,aqv3:2,cqv2:2,cqv3:2,
 	bks:3,bkd:3,hdm:3,box:3,tr1:3,ass:3,msf:3,vip:3,hst:3,j34:3,g34:3,xyz:3,g33:3,bbb:3,qbr:3,qey:3,qhr:3,qf1:3,qf2:3,mss:3,hfh:3,ice:3,tr2:3,
 	crfb:3,crfc:3,crfs:3,crfh:3,crfv:3,crfu:3,crfp:3,

--- a/data/item_metadata.js
+++ b/data/item_metadata.js
@@ -1563,7 +1563,7 @@ var all_codes = {
 	NORM:3,EXC:3,ELT:3,NMAG:3,MAG:3,RARE:3,UNI:3,SET:3,ID:3,ETH:3,INF:3,SUP:3,RW:3,
 	CL1:3,CL2:3,CL3:3,CL4:3,CL5:3,CL6:3,CL7:3,
 	EQ1:3,EQ2:3,EQ3:3,EQ4:3,EQ5:3,EQ6:3,EQ7:3,ARMOR:3,
-	WP1:3,WP2:3,WP3:3,WP4:3,WP5:3,WP6:3,WP7:3,WP8:3,WP9:3,WP10:3,WP11:3,WP12:3,WP13:3,WEAPON:3,CHARM:3,
+	WP1:3,WP2:3,WP3:3,WP4:3,WP5:3,WP6:3,WP7:3,WP8:3,WP9:3,WP10:3,WP11:3,WP12:3,WP13:3,WEAPON:3,CHARM:3,JEWELRY:3,QUIVER:3,MISC:3,
 	amu:3,rin:3,aqv:3,cqv:3,aq2:1,cq2:1,aqv2:2,aqv3:2,cqv2:2,cqv3:2,
 	bks:3,bkd:3,hdm:3,box:3,tr1:3,ass:3,msf:3,vip:3,hst:3,j34:3,g34:3,xyz:3,g33:3,bbb:3,qbr:3,qey:3,qhr:3,qf1:3,qf2:3,mss:3,hfh:3,ice:3,tr2:3,
 	crfb:3,crfc:3,crfs:3,crfh:3,crfv:3,crfu:3,crfp:3,
@@ -1598,7 +1598,7 @@ var all_codes = {
 	AXE:3,MACE:3,SWORD:3,DAGGER:3,THROWING:3,JAV:2,SPEAR:3,POLEARM:3,BOW:3,XBOW:3,STAFF:3,WAND:3,SCEPTER:3,_1H:2,_2H:2,	// JAV is a valid code in PoD, but doesn't seem to match with javelins
 	wss:2,lbox:2,dcma:2,dcbl:2,dcho:2,dcso:2,imra:2,imma:2,scou:2,rera:2,upma:2,upmp:2,scrb:2,ubtm:2,jewf:2,rtma:2,rtmo:2,rtmv:2,rtmf:2,cwss:2,rar:2,rbe:2,ram:2,rid:2,rtp:2,lpp:2,llmr:2,lsvl:2,ubaa:2,ubab:2,ubac:2,uba:2,rkey:2,fort:2,lmal:2,iwss:2,cm2f:2,pvpp:2,irma:2,irra:2,urma:2,rrra:2,
 	AMAZON:2,ASSASSIN:2,BARBARIAN:2,DRUID:2,NECROMANCER:2,PALADIN:2,SORCERESS:2,
-	PREFIX:2,SUFFIX:2,MAPID:2,SHOP:2,EQUIPPED:2,GEMMED:2,GROUND:2,INVENTORY:2,STASH:2,MERC:2,QUIVER:2,imrn:2,luca:2,lucb:2,lucc:2,lucd:2,_7cr2:2,cm1p:2,cm2p:2,cm3p:2,BUYPRICE:2,SELLPRICE:2,
+	PREFIX:2,SUFFIX:2,MAPID:2,SHOP:2,EQUIPPED:2,GEMMED:2,GROUND:2,INVENTORY:2,STASH:2,MERC:2,imrn:2,luca:2,lucb:2,lucc:2,lucd:2,_7cr2:2,cm1p:2,cm2p:2,cm3p:2,BUYPRICE:2,SELLPRICE:2,
 	ivea:2,ivez:2,iveb:2,ived:2,iven:2,ivep:2,ives:2,t3b:2,
 	t10:2,t11:2,t12:2,t13:2,t14:2,t15:2,t16:2,t17:2,t18:2,t20:2,t19:2,t21:2,t22:2,t23:2,t24:2,t25:2,t26:2,t27:2,t28:2,t29:2,t30:2,t31:2,t32:2,t33:2,t34:2,t35:2,t36:2,t37:2,t38:2,t39:2,t3a:2,t40:2,t41:2,t42:2,t43:2,t44:2,t45:2,t46:2,t47:2,t48:2,t49:2,t50:2,t51:2,t52:2,t53:2,t54:2,t55:2,t56:2,t57:2,t58:2,t59:2,t60:2,t61:2,t62:2,t63:2,t64:2,t65:2,t66:2,t67:2,t68:2,t69:2,
 	r01s:2,r02s:2,r03s:2,r04s:2,r05s:2,r06s:2,r07s:2,r08s:2,r09s:2,r10s:2,r11s:2,r12s:2,r13s:2,r14s:2,r15s:2,r16s:2,r17s:2,r18s:2,r19s:2,r20s:2,r21s:2,r22s:2,r23s:2,r24s:2,r25s:2,r26s:2,r27s:2,r28s:2,r29s:2,r30s:2,r31s:2,r32s:2,r33s:2,

--- a/data/simulation.js
+++ b/data/simulation.js
@@ -261,6 +261,7 @@ function setItem(value) {
 					if (item.size == "small") { itemToCompare.CODE = "cm1"; itemToCompare.base = "Small Charm"; }
 					else if (item.size == "large") { itemToCompare.CODE = "cm2"; itemToCompare.base = "Large Charm"; }
 					else if (item.size == "grand") { itemToCompare.CODE = "cm3"; itemToCompare.base = "Grand Charm"; }
+					itemToCompare.CHARM = true;
 				}
 					if (item.type == "jewel") { itemToCompare.CODE = "jew"; itemToCompare.base = "Jewel"; }
 					else if (item.type == "rune") {

--- a/data/simulation.js
+++ b/data/simulation.js
@@ -255,8 +255,8 @@ function setItem(value) {
 				else if (base.tier == 2) { itemToCompare.EXC = true }
 				else if (base.tier == 3) { itemToCompare.ELT = true }
 			} else {
-				if (group == "amulet" && typeof(itemToCompare.CODE) == 'undefined') { itemToCompare.CODE = "amu"; itemToCompare.base = "Amulet"; }
-				else if (group == "ring") { itemToCompare.CODE = "rin"; itemToCompare.base = "Ring"; }
+				if (group == "amulet" && typeof(itemToCompare.CODE) == 'undefined') { itemToCompare.CODE = "amu"; itemToCompare.base = "Amulet"; itemToCompare.JEWELRY = true; }
+				else if (group == "ring") { itemToCompare.CODE = "rin"; itemToCompare.base = "Ring"; itemToCompare.JEWELRY = true; }
 				else if (group == "charms") {
 					if (item.size == "small") { itemToCompare.CODE = "cm1"; itemToCompare.base = "Small Charm"; }
 					else if (item.size == "large") { itemToCompare.CODE = "cm2"; itemToCompare.base = "Large Charm"; }
@@ -306,6 +306,7 @@ function setItem(value) {
 			itemToCompare[itemToCompare.CODE] = true
 			var quiverCodes = ["aqv","cqv","aqv2","aqv3","cqv2","cqv3","aq2","cq2"];
 			if (quiverCodes.indexOf(itemToCompare.CODE) >= 0 || itemToCompare.type == "quiver") { itemToCompare.QUIVER = true; }
+			if (group == "misc" || group == "runes" || itemToCompare.type == "rune" || itemToCompare.type == "gem" || itemToCompare.type == "misc" || itemToCompare.type == "other") { itemToCompare.MISC = true; }
 			if (typeof(itemToCompare.velocity) != 'undefined') { if (itemToCompare.velocity < 0) { itemToCompare.velocity += 100000 } }	// negative values overflow for this in-game code
 			if (typeof(itemToCompare.always_id) == 'undefined') { itemToCompare.always_id = false }
 			if (itemToCompare.always_id == false && item_settings.ID == false) { itemToCompare.ID = false }


### PR DESCRIPTION
## Summary
Adds four boolean conditions covering issues #23 and #24:

- **CHARM** — true for `cm1`, `cm2`, `cm3` (Small/Large/Grand Charm).
- **JEWELRY** — true for `amu` and `rin` (amulets and rings).
- **QUIVER** — true for `aqv`, `aqv2`, `aqv3`, `cqv`, `cqv2`, `cqv3`. (QUIVER was already partially wired in `setItem`; this PR extends it to the custom-editor flow, registers it in the `all_codes` validator as available in both PoD and PD2, and removes the stale PD2-only entry.)
- **MISC** — true for items in `misc.txt`: potions, gems, runes, ingredients, and quest items (covered via `equipment.misc` and `equipment.runes` groups, plus items with `type` of `rune`, `gem`, `misc`, or `other`).

### Files changed
- `data/item_metadata.js` — registers `CHARM:3`, `JEWELRY:3`, `QUIVER:3`, `MISC:3` in `all_codes`; drops the old `QUIVER:2` PD2-only entry.
- `data/simulation.js` — sets the new flags on items selected from the dropdown (`setItem`).
- `data/custom_items.js` — sets the new flags on items built via the advanced custom editor (`setCustomBase`).
- `README.md` — adds the new keywords to the Equipment types list and removes the redundant QUIVER reference from the PD2-only line.

Closes #23
Closes #24

## Test plan
- [ ] Open `index.html`, pick a Small/Large/Grand Charm and confirm `[CHARM]` matches.
- [ ] Pick a ring or amulet and confirm `[JEWELRY]` matches; confirm a charm/helm/etc. does NOT.
- [ ] Pick an Arrows/Bolts quiver (PoD and PD2 versions) and confirm `[QUIVER]` matches.
- [ ] Pick a potion / gem / rune / quest item and confirm `[MISC]` matches; confirm a regular weapon/armor does NOT.
- [ ] Repeat each via the advanced custom editor.
- [ ] Confirm `[CHARM]`, `[JEWELRY]`, `[QUIVER]`, `[MISC]` no longer raise "unrecognized code" warnings in either PD2 or PoD mode.