### PR TITLE
Fix #26: Raise filter level cap from 9 to 15

### DIFF
--- a/data/simulation.js
+++ b/data/simulation.js
@@ -2057,9 +2057,9 @@ function setLocation(value) {
 // setFilterLevel -
 // ---------------------------------
 function setFilterLevel(value) {
-	if (isNaN(value) == true || value < 0 || value > 9) {
+	if (isNaN(value) == true || value < 0 || value > 15) {
 		value = Number(character.FILTLVL);
-		if (value > 9) { value = 9 };
+		if (value > 15) { value = 15 };
 	}
 	document.getElementById("filtlvl").value = Number(value)
 	character.FILTLVL = Number(value)


### PR DESCRIPTION
## Summary

Raises the filter level cap from 9 to 15 so users can future-proof for upcoming filter tiers.

## Changes

- **`data/simulation.js`** (`setFilterLevel`, lines 2060/2062): replaced both `> 9` checks and the `value = 9` clamp with `15`, so input values 10-15 are now accepted instead of being snapped back.

## Notes

- The HTML input in `index.html` already had `max="15"` and the README already advertised 0-15, so the JS validator was the only place still enforcing the old 9 cap.
- No per-level scaffolding (color tiers, generated dropdown options, CSS classes, etc.) needed extending - the value is just stored on `character.FILTLVL` and compared numerically by filter conditions, so 10-15 work the same way 1-9 do.

## Test plan

- [ ] Type 15 into the Filter Level input - value sticks instead of being clamped to 9
- [ ] Type 99 - clamps back to last good value (still 15 max)
- [ ] Filter rules using `FILTLVL=10` (or any 10-15) now match correctly

Closes #26

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>